### PR TITLE
Fix dashboard data URLs to use GitHub raw content

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,10 +18,10 @@ This directory contains the GitHub Pages site that displays the real-time status
 
 ## Data Sources
 
-The dashboard reads directly from:
-- `../data/rio-hondo/schedule_202570_latest.json` - Rio Hondo College data
-- `../data/citrus/schedule_202620_latest.json` - Citrus College data  
-- `../data/mtsac/schedule_202520_latest.json` - Mt. San Antonio College data
+The dashboard reads directly from GitHub raw content:
+- `https://raw.githubusercontent.com/jmcpheron/ccc-schedule-collector/main/data/rio-hondo/schedule_202570_latest.json` - Rio Hondo College data
+- `https://raw.githubusercontent.com/jmcpheron/ccc-schedule-collector/main/data/citrus/schedule_202620_latest.json` - Citrus College data  
+- `https://raw.githubusercontent.com/jmcpheron/ccc-schedule-collector/main/data/mtsac/schedule_202520_latest.json` - Mt. San Antonio College data
 
 ## Testing Locally
 

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -2,22 +2,22 @@
 
 const REFRESH_INTERVAL = 60000; // Refresh every minute
 
-// College configurations - points directly to latest data files
+// College configurations - points directly to latest data files from GitHub raw content
 const COLLEGES = [
     {
         id: 'rio-hondo',
         name: 'Rio Hondo College',
-        dataUrl: '../data/rio-hondo/schedule_202570_latest.json'
+        dataUrl: 'https://raw.githubusercontent.com/jmcpheron/ccc-schedule-collector/main/data/rio-hondo/schedule_202570_latest.json'
     },
     {
         id: 'citrus', 
         name: 'Citrus College',
-        dataUrl: '../data/citrus/schedule_202620_latest.json'
+        dataUrl: 'https://raw.githubusercontent.com/jmcpheron/ccc-schedule-collector/main/data/citrus/schedule_202620_latest.json'
     },
     {
         id: 'mtsac',
         name: 'Mt. San Antonio College', 
-        dataUrl: '../data/mtsac/schedule_202520_latest.json'
+        dataUrl: 'https://raw.githubusercontent.com/jmcpheron/ccc-schedule-collector/main/data/mtsac/schedule_202520_latest.json'
     }
 ];
 


### PR DESCRIPTION
Update dashboard.js to fetch data files from raw GitHub URLs instead of relative paths, since GitHub Pages only publishes the docs/ directory and doesn't include the data/ folder.

Changes:
- Update all college dataUrl entries to use https://raw.githubusercontent.com URLs
- Update docs/README.md data sources section to reflect correct URLs
- Enables dashboard to work properly on GitHub Pages

🤖 Generated with [Claude Code](https://claude.ai/code)